### PR TITLE
fix: include staged release changes in dry run

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Create dry-run patch
         if: inputs.dry_run == true
-        run: git diff --binary > release.patch
+        run: git diff --binary HEAD > release.patch
 
       - name: Upload dry-run artifacts
         if: inputs.dry_run == true


### PR DESCRIPTION
The Prepare release dry-run artifact used the unstaged diff, while Towncrier stages the changelog section and fragment deletion. Compare against HEAD so the artifact contains both staged and unstaged release changes. This does not affect the non-dry-run path.