### PR TITLE
Fix release artifact signing

### DIFF
--- a/.github/workflows/_publish.yaml
+++ b/.github/workflows/_publish.yaml
@@ -126,15 +126,19 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Sign release artifacts
-        uses: sigstore/gh-action-sigstore-python@5b79a39c381910c090341a2c9b0bf022c8b387e1 # v3.4.0
-        with:
-          inputs: >-
-            dist/*.whl
-            dist/*.tar.gz
-          verify: true
-          verify-cert-identity: https://github.com/${{ github.repository }}/.github/workflows/_publish.yaml@refs/tags/${{ inputs.version }}
-          verify-oidc-issuer: https://token.actions.githubusercontent.com
+      - name: Sign and verify release artifacts
+        run: |
+          set -euo pipefail
+          certificate_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/_publish.yaml@refs/tags/${RELEASE_VERSION}"
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            bundle="${artifact}.sigstore.json"
+            cosign sign-blob --yes --bundle "${bundle}" "${artifact}"
+            cosign verify-blob \
+              --bundle "${bundle}" \
+              --certificate-identity "${certificate_identity}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${artifact}"
+          done
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/recover-0.10.0.yaml
+++ b/.github/workflows/recover-0.10.0.yaml
@@ -1,0 +1,127 @@
+name: Recover release 0.10.0
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: recover-release-0.10.0
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    name: Sign artifacts and create GitHub Release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read # Download the immutable artifact from the original run.
+      contents: write # Create the GitHub Release.
+      id-token: write # Sign artifacts with Sigstore.
+    env:
+      RELEASE_VERSION: "0.10.0"
+      SOURCE_RUN_ID: "30535564290"
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/tags/0.10.0
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$(git cat-file -t "refs/tags/${RELEASE_VERSION}")" = tag
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" --jq .head_sha)" = "$(git rev-parse HEAD)"
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" --jq .event)" = push
+          git fetch origin master
+          git merge-base --is-ancestor HEAD origin/master
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.31"
+          checksum: "8cc1cd82d434ec565376f98bd938d4b715b5791a80ff2d3aa78821cf85091b4b"
+          python-version: "3.10"
+          enable-cache: false
+
+      - name: Download original distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-dist
+          path: dist/
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: 30535564290
+
+      - name: Validate release
+        run: |
+          uv run python -m tools.release validate-release \
+            --version "${RELEASE_VERSION}" \
+            --pyproject pyproject.toml \
+            --lockfile uv.lock \
+            --changelog CHANGELOG.md
+          uv run python -m tools.release artifacts \
+            --version "${RELEASE_VERSION}" \
+            --directory dist \
+            --output dist/SHA256SUMS.json
+          uv run python -m tools.release notes \
+            --version "${RELEASE_VERSION}" \
+            --changelog CHANGELOG.md \
+            --output release-notes.md
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign and verify release artifacts
+        run: |
+          set -euo pipefail
+          certificate_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/recover-0.10.0.yaml@refs/heads/master"
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            bundle="${artifact}.sigstore.json"
+            cosign sign-blob --yes --bundle "${bundle}" "${artifact}"
+            cosign verify-blob \
+              --bundle "${bundle}" \
+              --certificate-identity "${certificate_identity}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${artifact}"
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_status="$(curl \
+            --silent \
+            --show-error \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_VERSION}")"
+          test "${release_status}" = "404"
+          gh release create "${RELEASE_VERSION}" \
+            --verify-tag \
+            --title "${RELEASE_VERSION}" \
+            --notes-file release-notes.md \
+            dist/*
+
+  deploy-release-docs:
+    name: Deploy release documentation
+    needs: recover
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: write # Dispatch the documentation workflow.
+    steps:
+      - name: Dispatch documentation deployment
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docs.yaml -f version="0.10.0"

--- a/changes/+release-signing.fixed.md
+++ b/changes/+release-signing.fixed.md
@@ -1,0 +1,2 @@
+Use the installed Cosign CLI for release signing so project Python settings
+cannot interfere with Sigstore's environment.


### PR DESCRIPTION
## What changed

- replace the Python Sigstore action with the installed Cosign CLI
- sign and immediately verify wheel and sdist bundles with the exact workflow identity
- add a one-time recovery workflow for release 0.10.0 using immutable artifacts from run 30535564290
- keep the fix in the automated changelog

## Root cause

setup-uv exported UV_PYTHON=3.10. The Sigstore Python action then created Python 3.14, but uv pip selected the project Python instead of the action environment, leaving the action without sigstore and requests.

## Validation

- reproduced uv interpreter selection locally
- actionlint passed
- zizmor pedantic reported no findings
- Towncrier draft passed
- git diff --check passed
- baseline suite passed: 221 tests on Python 3.14