### PR TITLE
Add project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/assets/logo.svg" alt="asyncly logo" width="120">
+</p>
+
 # Asyncly
 
 [![PyPI version](https://img.shields.io/pypi/v/asyncly.svg)](https://pypi.org/project/asyncly/)

--- a/changes/+project-logo.docs.md
+++ b/changes/+project-logo.docs.md
@@ -1,0 +1,1 @@
+Added the project logo to the README and documentation header and favicon.

--- a/docs/assets/logo-white.svg
+++ b/docs/assets/logo-white.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke-linecap="round" stroke-width="8">
+    <path d="M10.7 26.3 A22 22 0 0 1 50 19.4" stroke="#FFFFFF"/>
+    <path d="M53.3 37.7 A22 22 0 0 1 14 44.6" stroke="#26C6DA"/>
+  </g>
+  <path d="M9 0 L-4 -7.5 L-4 7.5 Z" transform="translate(50 19.4) rotate(55)" fill="#FFFFFF"/>
+  <path d="M9 0 L-4 -7.5 L-4 7.5 Z" transform="translate(14 44.6) rotate(235)" fill="#26C6DA"/>
+  <circle cx="32" cy="32" r="6.5" fill="#A7FFEB"/>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke-linecap="round" stroke-width="8">
+    <path d="M10.7 26.3 A22 22 0 0 1 50 19.4" stroke="#00796B"/>
+    <path d="M53.3 37.7 A22 22 0 0 1 14 44.6" stroke="#26C6DA"/>
+  </g>
+  <path d="M9 0 L-4 -7.5 L-4 7.5 Z" transform="translate(50 19.4) rotate(55)" fill="#00796B"/>
+  <path d="M9 0 L-4 -7.5 L-4 7.5 Z" transform="translate(14 44.6) rotate(235)" fill="#26C6DA"/>
+  <circle cx="32" cy="32" r="6.5" fill="#00BFA5"/>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ copyright: Copyright &copy; Sergey Natalenko
 theme:
   name: material
   language: en
+  logo: assets/logo-white.svg
+  favicon: assets/logo.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
## What changed

- add color and white SVG logo variants
- show the color logo in the GitHub README
- use the white logo in the MkDocs header and the color logo as favicon
- add a documentation changelog fragment

## Validation

- both SVG files pass xmllint
- mkdocs build --strict passes
- generated HTML references both assets
- git diff --check passes